### PR TITLE
Improved sidebar UX

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -132,8 +132,16 @@ function SidebarToggle() {
   else {
     openSidebar();
     document.body.addEventListener('click', function(event) {
-      var sidebar = document.getElementsByClassName('left')[0];
-      if(!sidebar.contains(event.target)) {  //In case the user clicks outside the sidebar, the sidebar closes
+      var sidebar = document.getElementsByClassName('left')[0]; //Ensuring that clicks inside the sidebar(outside lobbies) don't make the sidebar collapse
+      var lobbyName = document.getElementsByClassName('person'); //In case user clicks a lobby from the sidebar, the sidebar collapse. This is a list of classes
+      var addLobbyPage = document.getElementById('room'); //Ensuring that clicks on page to add lobby names doesn't make the sidebar collapse
+      for (var i=0; i<lobbyName.length; i++) { 
+        if(lobbyName[i].contains(event.target)) {
+          closeSidebar(); 
+          return;
+        }
+      }
+      if(!sidebar.contains(event.target) && !addLobbyPage.contains(event.target)) { 
         closeSidebar(); 
       }
     }, false); 


### PR DESCRIPTION
I have added 2 features: [On Mobile View]

* Sidebar will collapse when a lobby is clicked. Right now, if a user clicks a lobby to enter it, the sidebar doesn't close automatically and has to be manually closed. The Usage flow will stay when the sidebar closes automatically when a lobby is clicked on.

* Sidebar will not collapse when adding a new room. From the earlier commit that I made, in case the click is outside the sidebar (even when entering new room's name) the sidebar collapses. The usage flow will stay if the sidebar doesn't close when the user tries to add another lobby.
