### PR TITLE
fix menu disappear after resizing window

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -108,7 +108,8 @@ function writeEmoji(emoji) {
 
 function closeSidebar() {
   const navbar = document.querySelector(".left");
-  navbar.style.left = '-300px';
+  navbar.classList.remove('open-menu')
+  navbar.classList.add('menu-closed')
   right.style.width = "100%";
   var toggle = document.querySelector("#toggle-icon");
   toggle.className = '';
@@ -117,7 +118,8 @@ function closeSidebar() {
 
 function openSidebar() { 
   const navbar = document.querySelector(".left");
-  navbar.style.left = '0px';
+  navbar.classList.remove('menu-closed')
+  navbar.classList.add('open-menu')
   right.style.width = "calc(100% - 300px)";
   var toggle = document.querySelector("#toggle-icon");
   toggle.className = '';
@@ -126,7 +128,7 @@ function openSidebar() {
 
 function SidebarToggle() {
   const navbar = document.querySelector(".left");
-  if (navbar.style.left == '0px') {
+  if (!navbar.classList.contains('menu-closed') && navbar.classList.contains('open-menu')) {
     closeSidebar();
   } 
   else {

--- a/public/style.css
+++ b/public/style.css
@@ -389,11 +389,15 @@ body {
   .sidebar-btn {
     visibility: visible;
   }
-
-  .left {
-    left: -300px;
+  .menu-closed{
+    left:-300px !important;
   }
-
+  .open-menu {
+    left: 0px !important;
+  }
+  .left{
+    left:-300px;
+  }
   .right {
     width: 100% !important;
     display: block;


### PR DESCRIPTION
## Solution
Add menu-close class to the left menu that will have effect only on 900px breakpoint 


### BEFORE
<a href="https://www.loom.com/share/f5b6ccbebcb14e1f90e924d14a3cf8cb"> <p>Baat Cheet Sidebar bug</p> <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/f5b6ccbebcb14e1f90e924d14a3cf8cb-with-play.gif"> </a>
### AFTER
<a href="https://www.loom.com/share/7510670f728042b39c8d427f90ca1f8e"> <p>Baat Cheet Sidebar bug fix</p> <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/b33476561def4ee2b8287258d8d2e4ef-with-play.gif"> </a>