### PR TITLE
Use shift + enter for newlines, and Enter to send msg

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1,16 +1,19 @@
 $(document).ready(function () {
 	$("#userN").on("keypress", (val) => {
 		if (val.which == 13) setUsername();
-	});
-	// event listener to dynamic element
-	$("body").on("keypress", '.textarea', function (val) {
-		if (val.which == 13 && val.shiftKey) {
-			val.preventDefault();
-			sendMessage($(this).val());
+  });
+
+	// event listener for the main textarea
+	$("textarea").on("keyup",function (event) {
+		if (event.which == 13 && event.shiftKey) {
+			event.preventDefault();
+		} else if (event.which == 13) {
+      event.preventDefault();
+      sendMessage($(this).val());
 			$(this).val("");
-		}
+    }
 	});
-	$("body").on("click", '.send', function () {
+	$(".send").on("click", function () {
 		const input = $(this).parents('.write').find('.textarea');
 		sendMessage(input.val());
 		input.val("");


### PR DESCRIPTION
Use `Shift` + `Enter`  for newlines, and `Enter` to send msg. This is the traditional way to send messages through every app I have ever used. It also makes the most sense for mobile clients.

- removed event listeners from the body (bad perf) and added to only the el that needs them
- I don't even know that `event.preventDefault();` in the first conditional is necessary, but I stuck it in there just in case
- object that comes back in the callback has been renamed from `val` to `event` because it's the event that's returned, not a value